### PR TITLE
Fix run-time error

### DIFF
--- a/flake8_import_restrictions/imports_submodule.py
+++ b/flake8_import_restrictions/imports_submodule.py
@@ -30,7 +30,7 @@ def imports_submodule(
 
     try:
         parent = importlib.import_module("." * level + from_, package)
-    except ImportError:
+    except (ImportError, TypeError):
         return None
     if not hasattr(parent, import_):
         try:


### PR DESCRIPTION
This fixes following error I encountered when trying to use the plugin:
```
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/pool.py", line 121, in worker
    result = (True, func(*args, **kwds))
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8/checker.py", line 676, in _run_checks
    return checker.run_checks()
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8/checker.py", line 589, in run_checks
    self.run_ast_checks()
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8/checker.py", line 494, in run_ast_checks
    for (line_number, offset, text, _) in runner:
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8_import_restrictions/checker.py", line 122, in run
    yield from _i2041(node, self.filename)
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8_import_restrictions/checker.py", line 284, in _i2041
    if not imports_submodule(filename, node.level, node.module, name.name):
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8_import_restrictions/imports_submodule.py", line 32, in imports_submodule
    parent = importlib.import_module("." * level + from_, package)
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/__init__.py", line 122, in import_module
    raise TypeError(msg.format(name))
TypeError: the 'package' argument is required to perform a relative import for '.config'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8/__main__.py", line 4, in <module>
    cli.main()
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8/main/cli.py", line 22, in main
    app.run(argv)
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8/main/application.py", line 363, in run
    self._run(argv)
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8/main/application.py", line 351, in _run
    self.run_checks()
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8/main/application.py", line 264, in run_checks
    self.file_checker_manager.run()
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8/checker.py", line 321, in run
    self.run_parallel()
  File "/Users/levneiman/dev/codebase/venv/lib/python3.7/site-packages/flake8/checker.py", line 287, in run_parallel
    for ret in pool_map:
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/pool.py", line 354, in <genexpr>
    return (item for chunk in result for item in chunk)
  File "/usr/local/opt/python@3.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/pool.py", line 748, in next
    raise value
TypeError: the 'package' argument is required to perform a relative import for '.config'

```